### PR TITLE
feat: add carbon support for cache expiry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.1",
-        "sammyjo20/saloon": "^2.0"
+        "sammyjo20/saloon": "^2.5"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",
@@ -26,7 +26,8 @@
         "spatie/ray": "^1.34.2",
         "league/flysystem": "^3.12.2",
         "orchestra/testbench": "^8.0",
-        "psr/simple-cache": "^3.0"
+        "psr/simple-cache": "^3.0",
+        "nesbot/carbon": "^2.66"
     },
     "scripts": {
         "test": [
@@ -35,6 +36,9 @@
         "fix-code": [
             "./vendor/bin/php-cs-fixer fix --allow-risky=yes"
         ]
+    },
+    "suggest": {
+        "nesbot/carbon": "Required to use a DateTime as a cache expiry."
     },
     "config": {
         "allow-plugins": {

--- a/src/Contracts/Cacheable.php
+++ b/src/Contracts/Cacheable.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Saloon\CachePlugin\Contracts;
 
+use Carbon\CarbonInterface;
+
+/**
+ * @method int|CarbonInterface cacheExpiry
+ */
 interface Cacheable
 {
     /**
@@ -12,11 +17,4 @@ interface Cacheable
      * @return \Saloon\CachePlugin\Contracts\Driver
      */
     public function resolveCacheDriver(): Driver;
-
-    /**
-     * Define the cache expiry in seconds
-     *
-     * @return int
-     */
-    public function cacheExpiryInSeconds(): int;
 }

--- a/src/Traits/HasCaching.php
+++ b/src/Traits/HasCaching.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Saloon\CachePlugin\Traits;
 
+use Carbon\Carbon;
 use Saloon\Enums\Method;
+use Saloon\Contracts\Request;
+use Saloon\Contracts\Connector;
 use Saloon\Contracts\PendingRequest;
 use Saloon\CachePlugin\Contracts\Cacheable;
 use Saloon\CachePlugin\Exceptions\HasCachingException;
@@ -54,9 +57,7 @@ trait HasCaching
             ? $request->resolveCacheDriver()
             : $connector->resolveCacheDriver();
 
-        $cacheExpiryInSeconds = $request instanceof Cacheable
-            ? $request->cacheExpiryInSeconds()
-            : $connector->cacheExpiryInSeconds();
+        $cacheExpiryInSeconds = $this->getCacheExpiryInSeconds($request, $connector);
 
         // Register a request middleware which wil handle the caching and recording
         // of real responses for caching.
@@ -64,6 +65,34 @@ trait HasCaching
         $pendingRequest->middleware()->onRequest(
             callable: new CacheMiddleware($cacheDriver, $cacheExpiryInSeconds, $this->cacheKey($pendingRequest), $this->invalidateCache),
         );
+    }
+
+    /**
+     * Get the cache expiration in seconds
+     */
+    protected function getCacheExpiryInSeconds(Request $request, Connector $connector): int
+    {
+        $expirator = $request instanceof Cacheable ? $request : $connector;
+
+        if (! method_exists($expirator, 'cacheExpiryInSeconds') && ! method_exists($expirator, 'cacheExpiry')) {
+            throw new \Exception(sprintf('Method [cacheExpiry] must be implemented on %s.', $expirator::class));
+        }
+
+        $expiry = method_exists($expirator, 'cacheExpiryInSeconds')
+            ? $expirator->cacheExpiryInSeconds()
+            : $expirator->cacheExpiry();
+
+        if (is_int($expiry)) {
+            return $expiry;
+        }
+
+        if (! class_exists(Carbon::class)) {
+            throw new \Exception(sprintf('nesbot/carbon is required to use %s as an expiry.', Carbon::class));
+        }
+
+        return is_int($expiry)
+            ? $expiry
+            : Carbon::now()->diffInRealSeconds($expiry);
     }
 
     /**

--- a/tests/Feature/CacheTest.php
+++ b/tests/Feature/CacheTest.php
@@ -13,6 +13,7 @@ use Saloon\CachePlugin\Tests\Fixtures\Requests\CachedPostRequest;
 use Saloon\CachePlugin\Tests\Fixtures\Requests\CachedUserRequest;
 use Saloon\CachePlugin\Tests\Fixtures\Requests\CachedConnectorRequest;
 use Saloon\CachePlugin\Tests\Fixtures\Requests\AllowedCachedPostRequest;
+use Saloon\CachePlugin\Tests\Fixtures\Requests\UserRequestWithoutExpiry;
 use Saloon\CachePlugin\Tests\Fixtures\Requests\CustomKeyCachedUserRequest;
 use Saloon\CachePlugin\Tests\Fixtures\Requests\ShortLivedCachedUserRequest;
 use Saloon\CachePlugin\Tests\Fixtures\Requests\CachedUserRequestUsingCarbon;
@@ -357,4 +358,18 @@ test('a request with the HasCaching trait will use `cacheExpiry` to determine th
     expect($responseB->isSimulated())->toBeTrue();
     expect($responseB->isCached())->toBeTrue();
     expect($responseB->header('X-Howdy'))->toEqual('Yeehaw');
+});
+
+test('it throws an exception if you use the HasCaching trait without an expiry method', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['name' => 'Sam']),
+    ]);
+
+    $connector = new TestConnector;
+    $request = new UserRequestWithoutExpiry;
+
+    $this->expectException(Exception::class);
+    $this->expectExceptionMessage('Method [cacheExpiry] must be implemented on Saloon\CachePlugin\Tests\Fixtures\Requests\UserRequestWithoutExpiry.');
+
+    $connector->send($request, $mockClient);
 });

--- a/tests/Fixtures/Requests/CachedUserRequestUsingCarbon.php
+++ b/tests/Fixtures/Requests/CachedUserRequestUsingCarbon.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\CachePlugin\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Carbon\CarbonInterface;
+use League\Flysystem\Filesystem;
+use Saloon\CachePlugin\Contracts\Driver;
+use Saloon\CachePlugin\Traits\HasCaching;
+use Saloon\CachePlugin\Contracts\Cacheable;
+use Saloon\CachePlugin\Drivers\FlysystemDriver;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+
+class CachedUserRequestUsingCarbon extends Request implements Cacheable
+{
+    use HasCaching;
+
+    /**
+     * Method
+     *
+     * @var \Saloon\Enums\Method
+     */
+    protected Method $method = Method::GET;
+
+    /**
+     * Resolve the API endpoint
+     *
+     * @return string
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/user';
+    }
+
+    /**
+     * Resolve the cache driver
+     *
+     * @return \Saloon\CachePlugin\Contracts\Driver
+     */
+    public function resolveCacheDriver(): Driver
+    {
+        return new FlysystemDriver(new Filesystem(new LocalFilesystemAdapter(cachePath())));
+    }
+
+    /**
+     * Define the cache expiry
+     */
+    public function cacheExpiry(): CarbonInterface
+    {
+        return now()->addMinute();
+    }
+}

--- a/tests/Fixtures/Requests/UserRequestWithoutExpiry.php
+++ b/tests/Fixtures/Requests/UserRequestWithoutExpiry.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\CachePlugin\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use League\Flysystem\Filesystem;
+use Saloon\CachePlugin\Contracts\Driver;
+use Saloon\CachePlugin\Traits\HasCaching;
+use Saloon\CachePlugin\Contracts\Cacheable;
+use Saloon\CachePlugin\Drivers\FlysystemDriver;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+
+class UserRequestWithoutExpiry extends Request implements Cacheable
+{
+    use HasCaching;
+
+    /**
+     * Method
+     *
+     * @var \Saloon\Enums\Method
+     */
+    protected Method $method = Method::GET;
+
+    /**
+     * Resolve the API endpoint
+     *
+     * @return string
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/user';
+    }
+
+    /**
+     * Resolve the cache driver
+     *
+     * @return \Saloon\CachePlugin\Contracts\Driver
+     */
+    public function resolveCacheDriver(): Driver
+    {
+        return new FlysystemDriver(new Filesystem(new LocalFilesystemAdapter(cachePath())));
+    }
+}


### PR DESCRIPTION
This pull request adds `nesbot/carbon` support for determining the cache TTL. 

I'm used to use `now()->addHour()` for the TTL on Laravel's caching utilities, so it was a bummer when migrating some code to Saloon to see it doesn't support this.

To achieve support for this feature without breaking change, the `Cacheable` interface has been changed to remove `cacheExpiryInSeconds`. Instead, the `HasCaching` trait uses `method_exists` to find either the deprecated `cacheExpiryInSeconds` or the new `cacheExpiry` method.

The new `cacheExpiry` can either return an `int` or a `CarbonInterface`. In either case, the cache expiry will be resolved to seconds internally to minimize changes to the codebase.

---

Note that I have other concerns with the DX, as stated in https://github.com/Sammyjo20/saloon-cache-plugin/issues/11, so maybe it's worth not accepting this PR and make a bigger refactor for a better Laravel integration